### PR TITLE
Add integration screenshot testing infrastructure

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -22,7 +22,7 @@ jobs:
         run: flutter pub get
 
       - name: Run screenshot integration test
-        run: flutter test integration_test/screenshot_test.dart --dart-define=CI=true
+        run: flutter test -d flutter-tester integration_test/screenshot_test.dart --dart-define=CI=true
 
       - name: Upload screenshots
         if: always()

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,33 @@
+name: Screenshot Integration Tests
+
+on:
+  pull_request:
+
+jobs:
+  run:
+    name: Run screenshot integration test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.6'
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run screenshot integration test
+        run: flutter test integration_test/screenshot_test.dart --dart-define=CI=true
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-screenshots
+          path: integration_test/screenshots
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+integration_test/screenshots/

--- a/integration_test/screenshot_test.dart
+++ b/integration_test/screenshot_test.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:camera/camera.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:path/path.dart' as p;
@@ -38,28 +40,38 @@ void main() {
       sensorOrientation: 0,
     );
 
-    await tester.pumpWidget(const MyApp(camera: fakeCamera));
+    final repaintBoundaryKey = GlobalKey();
+
+    await tester.pumpWidget(
+      RepaintBoundary(
+        key: repaintBoundaryKey,
+        child: const MyApp(camera: fakeCamera),
+      ),
+    );
     await tester.pump();
 
-    await _captureScreenshot(tester, binding, '01_splash_screen');
+    final boundary = repaintBoundaryKey.currentContext!
+        .findRenderObject()! as RenderRepaintBoundary;
+
+    await _captureScreenshot(tester, binding, boundary, '01_splash_screen');
 
     await tester.pump(const Duration(seconds: 4));
     await tester.pumpAndSettle();
 
-    await _captureScreenshot(tester, binding, '02_home_screen');
+    await _captureScreenshot(tester, binding, boundary, '02_home_screen');
 
     final timerButton = find.text('Go to Timer View');
     expect(timerButton, findsOneWidget);
     await tester.tap(timerButton);
     await tester.pumpAndSettle();
 
-    await _captureScreenshot(tester, binding, '03_timer_view');
+    await _captureScreenshot(tester, binding, boundary, '03_timer_view');
 
     final amrapButton = find.text('AMRAP');
     if (amrapButton.evaluate().isNotEmpty) {
       await tester.tap(amrapButton);
       await tester.pumpAndSettle();
-      await _captureScreenshot(tester, binding, '04_amrap_settings');
+      await _captureScreenshot(tester, binding, boundary, '04_amrap_settings');
       await tester.pageBack();
       await tester.pumpAndSettle();
     }
@@ -67,13 +79,14 @@ void main() {
     await tester.pageBack();
     await tester.pumpAndSettle();
 
-    await _captureScreenshot(tester, binding, '05_home_after_timer');
+    await _captureScreenshot(tester, binding, boundary, '05_home_after_timer');
   });
 }
 
 Future<void> _captureScreenshot(
   WidgetTester tester,
   IntegrationTestWidgetsFlutterBinding binding,
+  RenderRepaintBoundary boundary,
   String name,
 ) async {
   final directory = Directory(_screenshotDirectory);
@@ -82,18 +95,20 @@ Future<void> _captureScreenshot(
   }
 
   await tester.runAsync(() async {
-    final ui.Image image = await binding.renderView.toImage(
+    final ui.Image image = await boundary.toImage(
       pixelRatio:
           binding.platformDispatcher.implicitView?.devicePixelRatio ?? 1.0,
     );
     final ByteData? byteData =
         await image.toByteData(format: ui.ImageByteFormat.png);
     if (byteData == null) {
+      image.dispose();
       return;
     }
 
     final Uint8List pngBytes = byteData.buffer.asUint8List();
     final file = File(p.join(directory.path, '$name.png'));
     await file.writeAsBytes(pngBytes, flush: true);
+    image.dispose();
   });
 }

--- a/integration_test/screenshot_test.dart
+++ b/integration_test/screenshot_test.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:camera/camera.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:wodreplog/main.dart';
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
+
+  const outputDirectory = 'integration_test/screenshots';
+  binding.testOutputsDirectory = outputDirectory;
+
+  setUpAll(() {
+    final directory = Directory(outputDirectory);
+    if (!directory.existsSync()) {
+      directory.createSync(recursive: true);
+    }
+  });
+
+  testWidgets('captures screenshots of primary flows', (tester) async {
+    const fakeCamera = CameraDescription(
+      name: 'Test Camera',
+      lensDirection: CameraLensDirection.back,
+      sensorOrientation: 0,
+    );
+
+    await tester.pumpWidget(const MyApp(camera: fakeCamera));
+    await tester.pump();
+
+    await binding.takeScreenshot('01_splash_screen');
+
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pumpAndSettle();
+
+    await binding.takeScreenshot('02_home_screen');
+
+    final timerButton = find.text('Go to Timer View');
+    expect(timerButton, findsOneWidget);
+    await tester.tap(timerButton);
+    await tester.pumpAndSettle();
+
+    await binding.takeScreenshot('03_timer_view');
+
+    final amrapButton = find.text('AMRAP');
+    if (amrapButton.evaluate().isNotEmpty) {
+      await tester.tap(amrapButton);
+      await tester.pumpAndSettle();
+      await binding.takeScreenshot('04_amrap_settings');
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+    }
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    await binding.takeScreenshot('05_home_after_timer');
+  });
+}

--- a/integration_test/screenshot_test.dart
+++ b/integration_test/screenshot_test.dart
@@ -15,7 +15,8 @@ const _screenshotDirectory = String.fromEnvironment(
 );
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final IntegrationTestWidgetsFlutterBinding binding =
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() {
     final directory = Directory(_screenshotDirectory);
@@ -40,25 +41,25 @@ void main() {
     await tester.pumpWidget(const MyApp(camera: fakeCamera));
     await tester.pump();
 
-    await _captureScreenshot(tester, '01_splash_screen');
+    await _captureScreenshot(tester, binding, '01_splash_screen');
 
     await tester.pump(const Duration(seconds: 4));
     await tester.pumpAndSettle();
 
-    await _captureScreenshot(tester, '02_home_screen');
+    await _captureScreenshot(tester, binding, '02_home_screen');
 
     final timerButton = find.text('Go to Timer View');
     expect(timerButton, findsOneWidget);
     await tester.tap(timerButton);
     await tester.pumpAndSettle();
 
-    await _captureScreenshot(tester, '03_timer_view');
+    await _captureScreenshot(tester, binding, '03_timer_view');
 
     final amrapButton = find.text('AMRAP');
     if (amrapButton.evaluate().isNotEmpty) {
       await tester.tap(amrapButton);
       await tester.pumpAndSettle();
-      await _captureScreenshot(tester, '04_amrap_settings');
+      await _captureScreenshot(tester, binding, '04_amrap_settings');
       await tester.pageBack();
       await tester.pumpAndSettle();
     }
@@ -66,13 +67,15 @@ void main() {
     await tester.pageBack();
     await tester.pumpAndSettle();
 
-    await _captureScreenshot(tester, '05_home_after_timer');
+    await _captureScreenshot(tester, binding, '05_home_after_timer');
   });
 }
 
-Future<void> _captureScreenshot(WidgetTester tester, String name) async {
-  final binding = tester.binding as IntegrationTestWidgetsFlutterBinding;
-
+Future<void> _captureScreenshot(
+  WidgetTester tester,
+  IntegrationTestWidgetsFlutterBinding binding,
+  String name,
+) async {
   final directory = Directory(_screenshotDirectory);
   if (!directory.existsSync()) {
     directory.createSync(recursive: true);

--- a/integration_test/screenshot_test.dart
+++ b/integration_test/screenshot_test.dart
@@ -1,22 +1,32 @@
 import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:camera/camera.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:path/path.dart' as p;
 
 import 'package:wodreplog/main.dart';
 
-void main() {
-  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized()
-      as IntegrationTestWidgetsFlutterBinding;
+const _screenshotDirectory = String.fromEnvironment(
+  'SCREENSHOT_DIR',
+  defaultValue: 'integration_test/screenshots',
+);
 
-  const outputDirectory = 'integration_test/screenshots';
-  binding.testOutputsDirectory = outputDirectory;
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() {
-    final directory = Directory(outputDirectory);
+    final directory = Directory(_screenshotDirectory);
     if (!directory.existsSync()) {
       directory.createSync(recursive: true);
+    }
+
+    for (final entity in directory.listSync()) {
+      if (entity is File && entity.path.toLowerCase().endsWith('.png')) {
+        entity.deleteSync();
+      }
     }
   });
 
@@ -30,25 +40,25 @@ void main() {
     await tester.pumpWidget(const MyApp(camera: fakeCamera));
     await tester.pump();
 
-    await binding.takeScreenshot('01_splash_screen');
+    await _captureScreenshot(tester, '01_splash_screen');
 
     await tester.pump(const Duration(seconds: 4));
     await tester.pumpAndSettle();
 
-    await binding.takeScreenshot('02_home_screen');
+    await _captureScreenshot(tester, '02_home_screen');
 
     final timerButton = find.text('Go to Timer View');
     expect(timerButton, findsOneWidget);
     await tester.tap(timerButton);
     await tester.pumpAndSettle();
 
-    await binding.takeScreenshot('03_timer_view');
+    await _captureScreenshot(tester, '03_timer_view');
 
     final amrapButton = find.text('AMRAP');
     if (amrapButton.evaluate().isNotEmpty) {
       await tester.tap(amrapButton);
       await tester.pumpAndSettle();
-      await binding.takeScreenshot('04_amrap_settings');
+      await _captureScreenshot(tester, '04_amrap_settings');
       await tester.pageBack();
       await tester.pumpAndSettle();
     }
@@ -56,6 +66,31 @@ void main() {
     await tester.pageBack();
     await tester.pumpAndSettle();
 
-    await binding.takeScreenshot('05_home_after_timer');
+    await _captureScreenshot(tester, '05_home_after_timer');
+  });
+}
+
+Future<void> _captureScreenshot(WidgetTester tester, String name) async {
+  final binding = tester.binding as IntegrationTestWidgetsFlutterBinding;
+
+  final directory = Directory(_screenshotDirectory);
+  if (!directory.existsSync()) {
+    directory.createSync(recursive: true);
+  }
+
+  await tester.runAsync(() async {
+    final ui.Image image = await binding.renderView.toImage(
+      pixelRatio:
+          binding.platformDispatcher.implicitView?.devicePixelRatio ?? 1.0,
+    );
+    final ByteData? byteData =
+        await image.toByteData(format: ui.ImageByteFormat.png);
+    if (byteData == null) {
+      return;
+    }
+
+    final Uint8List pngBytes = byteData.buffer.asUint8List();
+    final file = File(p.join(directory.path, '$name.png'));
+    await file.writeAsBytes(pngBytes, flush: true);
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   flutter_launcher_icons: ^0.13.1
 
   # The "flutter_lints" package below contains a set of recommended lints to


### PR DESCRIPTION
## Summary
- add an integration test that captures screenshots of the main flows into a stable directory
- ignore generated screenshots and add the integration_test package for test support
- create a CI workflow to run the screenshot test and upload the resulting artifacts on pull requests

## Testing
- Not run (Flutter SDK unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de2a215ef08327ac8104224ee309b5