### PR TITLE
Fix YAML indentation for pubspec bump step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,31 +28,31 @@ jobs:
         id: bump_version
         run: |
           python <<'PY'
-            from pathlib import Path
-            import os
-            import re
-            
-            pubspec = Path("pubspec.yaml")
-            content = pubspec.read_text()
-            match = re.search(r"^version:\s*(\d+\.\d+\.\d+)(?:\+(\d+))?", content, re.MULTILINE)
-            if not match:
-                raise SystemExit("Unable to find version in pubspec.yaml")
-            
-            version_name = match.group(1)
-            build_number = int(match.group(2) or 0) + 1
-            new_line = f"version: {version_name}+{build_number}"
-            
-            updated = re.sub(r"^version:.*$", new_line, content, count=1, flags=re.MULTILINE)
-            pubspec.write_text(updated)
-            
-            with open(os.environ["GITHUB_OUTPUT"], "w", encoding="utf-8") as fh:
-                fh.write(f"version_name={version_name}\n")
-                fh.write(f"version_code={build_number}\n")
-            
-            with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
-                fh.write(f"VERSION_NAME={version_name}\n")
-                fh.write(f"VERSION_CODE={build_number}\n")
-            PY
+          from pathlib import Path
+          import os
+          import re
+
+          pubspec = Path("pubspec.yaml")
+          content = pubspec.read_text()
+          match = re.search(r"^version:\s*(\d+\.\d+\.\d+)(?:\+(\d+))?", content, re.MULTILINE)
+          if not match:
+              raise SystemExit("Unable to find version in pubspec.yaml")
+
+          version_name = match.group(1)
+          build_number = int(match.group(2) or 0) + 1
+          new_line = f"version: {version_name}+{build_number}"
+
+          updated = re.sub(r"^version:.*$", new_line, content, count=1, flags=re.MULTILINE)
+          pubspec.write_text(updated)
+
+          with open(os.environ["GITHUB_OUTPUT"], "w", encoding="utf-8") as fh:
+              fh.write(f"version_name={version_name}\n")
+              fh.write(f"version_code={build_number}\n")
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
+              fh.write(f"VERSION_NAME={version_name}\n")
+              fh.write(f"VERSION_CODE={build_number}\n")
+          PY
 
       - name: Commit version bump
         if: github.actor != 'github-actions[bot]'


### PR DESCRIPTION
## Summary
- reindent the Python heredoc within the build workflow so the YAML is valid while keeping the script aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df65d9862483279510f4caa0c93a09