### PR TITLE
Raise Android Gradle tooling to 8.9

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,8 +35,12 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
     }
 
     defaultConfig {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '7.4.2' apply false
+    id "com.android.application" version '8.9.0' apply false
     id "org.jetbrains.kotlin.android" version "1.9.25" apply false
 }
 


### PR DESCRIPTION
## Summary
- update the Android Gradle Plugin declaration to version 8.9.0
- bump the Gradle wrapper distribution to 8.9 to satisfy the plugin requirements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df6f8cc8cc83278e7bc266e5c93acf