### PR TITLE
chore: enable flutter and android renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,25 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "enabledManagers": [
+    "pub",
+    "gradle",
+    "gradle-wrapper"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "pub",
+        "gradle",
+        "gradle-wrapper"
+      ],
+      "groupName": "Flutter and Android dependencies",
+      "labels": [
+        "dependencies",
+        "flutter",
+        "android"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- ensure Renovate monitors Flutter pubspec dependencies and Android Gradle artifacts
- group related updates under a shared "Flutter and Android dependencies" label set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df7392fde88327a8692d88d0b13146