### PR TITLE
Update Gradle wrapper to 8.11.1

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- update the Android Gradle wrapper to version 8.11.1 to satisfy the plugin requirement

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68df741085a48327b8f0330142722080