### PR TITLE
Move runner manifests out of infra directory

### DIFF
--- a/argocd/applications/actions-runner-controller.yaml
+++ b/argocd/applications/actions-runner-controller.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: actions-runner-controller
+  namespace: argocd
+spec:
+  project: infra
+  source:
+    repoURL: https://actions-runner-controller.github.io/actions-runner-controller
+    chart: actions-runner-controller
+    targetRevision: 0.23.2
+    helm:
+      releaseName: actions-runner-controller
+      parameters:
+        - name: authSecret.create
+          value: "false"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: actions-runner-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/applications/github-runners.yaml
+++ b/argocd/applications/github-runners.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: github-runners
+  namespace: argocd
+spec:
+  project: infra
+  source:
+    repoURL: https://github.com/jLemmings/WODRepLog.git
+    targetRevision: HEAD
+    path: github-runners
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: actions-runner-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/github-runners/README.md
+++ b/github-runners/README.md
@@ -1,0 +1,70 @@
+# GitHub Runner Deployment with Argo CD
+
+This directory contains the Kubernetes manifests that provision self-hosted
+GitHub Actions runners on Kubernetes using
+[actions-runner-controller](https://github.com/actions/actions-runner-controller).
+They are designed to be deployed by Argo CD without Kustomize.
+
+## Prerequisites
+
+1. Argo CD installed in your cluster and configured with the `argocd` namespace.
+2. A functional GitHub personal access token (PAT) with `admin:org` scope for
+   organization runners.
+3. The `actions-runner-controller` Argo CD application defined in
+   `../argocd/applications/actions-runner-controller.yaml` synced first so the
+   CRDs exist before these manifests are applied.
+4. [External Secrets Operator](https://external-secrets.io/) installed in the
+   cluster with a configured `ClusterSecretStore` named
+   `github-runner-secrets` that surfaces your GitHub credentials. Adjust the
+   name in the manifests if you use a different store.
+
+## Configuration
+
+Update the following placeholders before syncing the application:
+
+- `jLemmings`: Update the organization value in `runnerdeployment.yaml` and
+  `horizontalrunnerautoscaler.yaml` if your GitHub organization differs.
+- `github-runner-secrets`: Update the `secretStoreRef` in the ExternalSecret
+  manifests if you use a different `SecretStore` name.
+- `org-runner`: Replace the `remoteRef.key` value with the path to the
+  credentials inside your secret store. Both the controller manager and runner
+  ExternalSecrets reference the same key, which must expose a `github_token`
+  property containing the PAT.
+- `https://github.com/jLemmings/WODRepLog.git`: Update the Argo CD application at
+  `../argocd/applications/github-runners.yaml` with the repository URL that
+  contains this folder if it differs.
+
+## Deploying with Argo CD
+
+1. Add this repository to Argo CD (if it is not already registered).
+2. Apply both application manifests:
+
+   ```bash
+   kubectl apply -f argocd/applications/actions-runner-controller.yaml
+   kubectl apply -f argocd/applications/github-runners.yaml
+   ```
+
+3. In the Argo CD UI or CLI, sync the `actions-runner-controller` application
+   first.
+4. Once the controller is healthy, sync the `github-runners` application. Argo
+   CD will create:
+
+   - The `actions-runner-system` namespace
+   - External Secrets that pull your GitHub token(s) from the configured secret
+     store
+   - A `RunnerDeployment` pre-scaled to three pods
+   - A `HorizontalRunnerAutoscaler` that scales between three and six runners
+     based on workflow queue length
+
+5. Trigger a workflow in any repository within the `jLemmings` organization and
+   observe pods labeled `app=github-runner` spinning up in the namespace.
+
+## Customisation
+
+- Adjust `replicas` in `runnerdeployment.yaml` to change the baseline number of
+  runners.
+- Modify the autoscaler thresholds in `horizontalrunnerautoscaler.yaml` to tune
+  responsiveness to queued jobs.
+- Extend the manifests with additional environment variables to mount Docker
+  registry credentials, Kubernetes service accounts, or custom runner images as
+  required by your workloads.

--- a/github-runners/controller-manager-externalsecret.yaml
+++ b/github-runners/controller-manager-externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: controller-manager-token
+  namespace: actions-runner-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: github-runner-secrets
+    kind: ClusterSecretStore
+  target:
+    name: controller-manager
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    - secretKey: github_token
+      remoteRef:
+        key: org-runner
+        property: github_token

--- a/github-runners/github-runner-externalsecret.yaml
+++ b/github-runners/github-runner-externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-runner-credentials
+  namespace: actions-runner-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: github-runner-secrets
+    kind: ClusterSecretStore
+  target:
+    name: github-runner-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+  data:
+    - secretKey: github_token
+      remoteRef:
+        key: org-runner
+        property: github_token

--- a/github-runners/horizontalrunnerautoscaler.yaml
+++ b/github-runners/horizontalrunnerautoscaler.yaml
@@ -1,0 +1,15 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: org-runners-autoscaler
+spec:
+  scaleTargetRef:
+    name: org-runners
+  minReplicas: 3
+  maxReplicas: 6
+  metrics:
+    - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+      organizationNames:
+        - jLemmings
+      scaleDownThreshold: 1
+      scaleUpThreshold: 2

--- a/github-runners/namespace.yaml
+++ b/github-runners/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: actions-runner-system

--- a/github-runners/runnerdeployment.yaml
+++ b/github-runners/runnerdeployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: org-runners
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: github-runner
+    spec:
+      organization: jLemmings
+      image: ghcr.io/actions/actions-runner:latest
+      labels:
+        - self-hosted
+        - linux
+        - x64
+      githubTokenRef:
+        name: github-runner-credentials
+        key: github_token
+      env:
+        - name: RUNNER_FEATURE_FLAG_EPHEMERAL
+          value: "true"
+      dockerdWithinRunnerContainer: true


### PR DESCRIPTION
## Summary
- relocate the actions-runner-controller and runner manifests from infra/ into top-level argocd/ and github-runners/ directories
- update the Argo CD application and documentation to reference the new paths

## Testing
- not run (infrastructure change)


------
https://chatgpt.com/codex/tasks/task_e_68df6b6a83488327946a40c2d509257d