### PR TITLE
Ignore Flutter internal plugin for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,16 @@
         "flutter",
         "android"
       ]
+    },
+    {
+      "description": "Ignore Flutter's internal Gradle plugin that is resolved from the local SDK.",
+      "matchDatasources": [
+        "gradle-plugin"
+      ],
+      "matchPackageNames": [
+        "dev.flutter.flutter-plugin-loader"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- disable updates for the Flutter plugin loader which Renovate cannot resolve because it is bundled with the local SDK

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df7501c078832795ffa637d7753ba5