### PR TITLE
Ignore Flutter plugin loader for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,8 @@
     {
       "description": "Ignore Flutter's internal Gradle plugin that is resolved from the local SDK.",
       "matchDatasources": [
-        "gradle-plugin"
+        "gradle-plugin",
+        "maven"
       ],
       "matchPackageNames": [
         "dev.flutter.flutter-plugin-loader"


### PR DESCRIPTION
## Summary
- extend the ignore rule for Flutter's Gradle plugin loader so Renovate does not attempt to resolve it from Maven

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df762f827c83279f1e9d7afc0dfb05