### PR TITLE
Adjust Renovate ignore rule for Flutter plugin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,8 +28,8 @@
         "gradle-plugin",
         "maven"
       ],
-      "matchPackageNames": [
-        "dev.flutter.flutter-plugin-loader"
+      "matchPackagePatterns": [
+        "^dev\\.flutter\\.flutter-plugin-loader"
       ],
       "enabled": false
     }

--- a/renovate.json
+++ b/renovate.json
@@ -28,8 +28,12 @@
         "gradle-plugin",
         "maven"
       ],
+      "matchPackageNames": [
+        "dev.flutter.flutter-plugin-loader",
+        "dev.flutter.flutter-plugin-loader:dev.flutter.flutter-plugin-loader.gradle.plugin"
+      ],
       "matchPackagePatterns": [
-        "^dev\\.flutter\\.flutter-plugin-loader"
+        "^dev\\.flutter\\.flutter-plugin-loader(?:$|:)"
       ],
       "enabled": false
     }


### PR DESCRIPTION
## Summary
- expand the Renovate ignore rule for Flutter's internal Gradle plugin to match the full package coordinate
- prevent Renovate from warning about the flutter-plugin-loader dependency that is resolved locally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df788b59f8832782f51a56c4216d10