### PR TITLE
Fix versionCode parsing and expand Renovate coverage

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,7 +50,7 @@ android {
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
-        versionCode = System.getenv("VERSION_CODE") ?: flutterVersionCode.toInteger()
+        versionCode = (System.getenv("VERSION_CODE") ?: flutterVersionCode).toInteger()
         versionName = System.getenv("VERSION_NAME") ?: flutterVersionName
         
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "enabledManagers": [
-    "pub",
-    "gradle",
-    "gradle-wrapper"
-  ],
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
## Summary
- ensure the Android build uses an integer versionCode even when set via environment variables
- allow Renovate to evaluate all dependency managers while keeping existing grouping rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df8bcf3f0c8327be1ce318c6196ede