### PR TITLE
Fix Gradle namespace configuration for gallery_saver plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,23 @@ subprojects {
         if (project.plugins.hasPlugin("com.android.application") ||
                 project.plugins.hasPlugin("com.android.library")) {
             project.android {
-                compileSdkVersion 34                
+                compileSdkVersion 34
+            }
+
+            if (project.plugins.hasPlugin("com.android.library") &&
+                    !project.android.hasProperty("namespace")) {
+                def manifestFile = project.file("src/main/AndroidManifest.xml")
+                if (manifestFile.exists()) {
+                    try {
+                        def manifest = new XmlParser(false, false).parse(manifestFile)
+                        def manifestPackage = manifest?.attributes()?.get("package")
+                        if (manifestPackage) {
+                            project.android.namespace = manifestPackage
+                        }
+                    } catch (Exception ignored) {
+                        // Best effort – namespace must be provided for AGP 8+.
+                    }
+                }
             }
         }
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,18 +15,24 @@ subprojects {
                 compileSdkVersion 34
             }
 
-            if (project.plugins.hasPlugin("com.android.library") &&
-                    !project.android.hasProperty("namespace")) {
-                def manifestFile = project.file("src/main/AndroidManifest.xml")
-                if (manifestFile.exists()) {
-                    try {
-                        def manifest = new XmlParser(false, false).parse(manifestFile)
-                        def manifestPackage = manifest?.attributes()?.get("package")
-                        if (manifestPackage) {
-                            project.android.namespace = manifestPackage
+            if (project.plugins.hasPlugin("com.android.library")) {
+                def currentNamespace = null
+                if (project.android.hasProperty("namespace")) {
+                    currentNamespace = project.android.namespace
+                }
+
+                if (!currentNamespace) {
+                    def manifestFile = project.file("src/main/AndroidManifest.xml")
+                    if (manifestFile.exists()) {
+                        try {
+                            def manifest = new XmlParser(false, false).parse(manifestFile)
+                            def manifestPackage = manifest?.attributes()?.get("package")
+                            if (manifestPackage) {
+                                project.android.namespace = manifestPackage
+                            }
+                        } catch (Exception ignored) {
+                            // Best effort – namespace must be provided for AGP 8+.
                         }
-                    } catch (Exception ignored) {
-                        // Best effort – namespace must be provided for AGP 8+.
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- configure Android library subprojects to adopt their manifest package as the Gradle namespace when one is not declared, ensuring the gallery_saver plugin builds successfully with AGP 8

## Testing
- not run (Flutter tooling unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df9673950083278c461e723d8d1677