### PR TITLE
Import XmlParser for namespace fallback

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+import groovy.util.XmlParser
+
 allprojects {
     repositories {
         google()
@@ -12,7 +14,29 @@ subprojects {
         if (project.plugins.hasPlugin("com.android.application") ||
                 project.plugins.hasPlugin("com.android.library")) {
             project.android {
-                compileSdkVersion 34                
+                compileSdkVersion 34
+            }
+
+            if (project.plugins.hasPlugin("com.android.library")) {
+                def currentNamespace = null
+                if (project.android.hasProperty("namespace")) {
+                    currentNamespace = project.android.namespace
+                }
+
+                if (!currentNamespace) {
+                    def manifestFile = project.file("src/main/AndroidManifest.xml")
+                    if (manifestFile.exists()) {
+                        try {
+                            def manifest = new XmlParser(false, false).parse(manifestFile)
+                            def manifestPackage = manifest?.attributes()?.get("package")
+                            if (manifestPackage) {
+                                project.android.namespace = manifestPackage
+                            }
+                        } catch (Exception ignored) {
+                            // Best effort – namespace must be provided for AGP 8+.
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add the missing groovy.util.XmlParser import so the manifest namespace fallback logic compiles

## Testing
- not run (Flutter tooling unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68df9673950083278c461e723d8d1677