### PR TITLE
Fix Gradle XmlParser import

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-import groovy.util.XmlParser
+import groovy.xml.XmlParser
 
 allprojects {
     repositories {


### PR DESCRIPTION
## Summary
- update the Groovy XmlParser import in the Android build script to use the correct package

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfa21cf2b88327a53f3acca4bad3b8