### PR TITLE
Add Groovy version check to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v5
 
+      - name: Check Groovy version
+        run: groovy -version
+
       - name: Configure Git user
         if: github.actor != 'github-actions[bot]'
         run: |


### PR DESCRIPTION
## Summary
- add a workflow step to print the Groovy version during CI builds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa43da334832790daa6a739dd725d