### PR TITLE
Install Groovy in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,15 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v5
 
+      - name: Install Groovy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y groovy
+
+      - name: Check Groovy version
+        run: |
+          groovy -version
+
       - name: Configure Git user
         if: github.actor != 'github-actions[bot]'
         run: |


### PR DESCRIPTION
## Summary
- install Groovy on the CI runner via apt so the tool is available
- keep the Groovy version check step to confirm the installation

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dfa43da334832790daa6a739dd725d