### PR TITLE
chore: rely on renovate for flutter dependency bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,8 @@
         "dependencies",
         "flutter",
         "android"
-      ]
+      ],
+      "rangeStrategy": "replace"
     },
     {
       "description": "Ignore Flutter's internal Gradle plugin that is resolved from the local SDK.",


### PR DESCRIPTION
## Summary
- revert the manual Flutter dependency constraint bumps so Renovate can manage the upgrades
- configure Renovate to use the `replace` range strategy for grouped Flutter and Android packages

## Testing
- not run (Flutter tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfbb0993b883278e9d8e2acacac9af