### PR TITLE
Fix Gradle build failure due to missing XmlParser dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,11 @@
 import groovy.util.XmlParser
 
+buildscript {
+    dependencies {
+        classpath localGroovy()
+    }
+}
+
 allprojects {
     repositories {
         google()


### PR DESCRIPTION
## Summary
- add the Gradle localGroovy dependency so that groovy.util.XmlParser is available during builds

## Testing
- not run (Gradle wrapper script is not present in the repository)


------
https://chatgpt.com/codex/tasks/task_e_68dfd89fc6508327b249d3ca2225a249