### PR TITLE
Ensure Groovy is available in release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       # Setup env variables that will be used throughout the workflow
       JAVA_VERSION: 19.0
-      FLUTTER_VERSION: 3.22.3
+      FLUTTER_VERSION: 3.35.5
       VERSION_NAME: ${{ github.event.release.tag_name }}
       VERSION_CODE: ${{github.run_number}}
 
@@ -56,7 +56,7 @@ jobs:
 
       # Bundle
       - name: Build release app bundle
-        run: flutter build appbundle
+        run: flutter build appbundle --release --build-number=${{ env.VERSION_CODE }} --build-name=${{ env.VERSION_NAME }}
 
       - name: Sign App Bundle
         uses: r0adkll/sign-android-release@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,15 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v5
 
+      - name: Install Groovy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y groovy
+
+      - name: Check Groovy version
+        run: |
+          groovy -version
+
       # Setup Java in the VM
       - uses: actions/setup-java@v5
         with:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,11 @@
 import groovy.util.XmlParser
 
+buildscript {
+    dependencies {
+        classpath localGroovy()
+    }
+}
+
 allprojects {
     repositories {
         google()


### PR DESCRIPTION
## Summary
- install Groovy on the release publish workflow so Gradle scripts can use XmlParser
- verify the Groovy installation by printing the version

## Testing
- not run (CI configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68dfd89fc6508327b249d3ca2225a249