### PR TITLE
Align Android library JVM target with Kotlin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 }
 
 import groovy.util.XmlParser
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 allprojects {
     repositories {
@@ -54,6 +55,19 @@ subprojects { project ->
                     } catch (Exception ignored) {
                         // Best effort – namespace must be provided for AGP 8+.
                     }
+                }
+            }
+
+            // Ensure Java/Kotlin compilation targets stay aligned across all
+            // library modules (including third-party plugins).
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+
+            project.tasks.withType(KotlinCompile).configureEach { task ->
+                task.kotlinOptions {
+                    jvmTarget = "17"
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure all Android library modules compile against Java 17 to match Kotlin's default
- configure Kotlin compilation tasks in library modules to target JVM 17 as well

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe8a14fd0832786f0c76a241f44c4