### PR TITLE
Improve camera resilience and recording timer UX

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,12 +1,18 @@
-import 'package:flutter/material.dart';
-import 'video_recorder.dart';
-import 'timer_view.dart';
 import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+
+import 'timer_view.dart';
+import 'video_recorder.dart';
 
 class HomeScreen extends StatelessWidget {
-  final CameraDescription camera;
+  const HomeScreen({
+    super.key,
+    required this.camera,
+    this.cameraError,
+  });
 
-  const HomeScreen({super.key, required this.camera});
+  final CameraDescription? camera;
+  final String? cameraError;
 
   @override
   Widget build(BuildContext context) {
@@ -23,29 +29,56 @@ class HomeScreen extends StatelessWidget {
         centerTitle: true,
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                      builder: (context) => const VideoRecorder()),
-                );
-              },
-              child: const Text('Go to Video Recorder'),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => const TimerView()),
-                );
-              },
-              child: const Text('Go to Timer View'),
-            ),
-          ],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              if (cameraError != null) ...[
+                Text(
+                  cameraError!,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Colors.redAccent,
+                  ),
+                ),
+                const SizedBox(height: 16),
+              ],
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: camera == null
+                      ? null
+                      : () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => VideoRecorder(
+                                camera: camera!,
+                              ),
+                            ),
+                          );
+                        },
+                  child: const Text('Go to Video Recorder'),
+                ),
+              ),
+              const SizedBox(height: 20),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const TimerView(),
+                      ),
+                    );
+                  },
+                  child: const Text('Go to Timer View'),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,29 +1,56 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+
 import 'splash_screen.dart';
-import 'theme.dart'; // Import the theme file
+import 'theme.dart';
 
-void main() async {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  final cameras = await availableCameras();
-  final firstCamera = cameras.first;
 
-  runApp(MyApp(camera: firstCamera));
+  CameraDescription? camera;
+  String? cameraError;
+
+  try {
+    final cameras = await availableCameras();
+    if (cameras.isNotEmpty) {
+      camera = cameras.first;
+    } else {
+      cameraError = 'No cameras available on this device.';
+    }
+  } on CameraException catch (error) {
+    cameraError = error.description ?? error.code;
+  } catch (error) {
+    cameraError = error.toString();
+  }
+
+  runApp(MyApp(
+    camera: camera,
+    cameraError: cameraError,
+  ));
 }
 
 class MyApp extends StatelessWidget {
-  final CameraDescription camera;
+  const MyApp({
+    super.key,
+    required this.camera,
+    this.cameraError,
+  });
 
-  const MyApp({super.key, required this.camera});
+  final CameraDescription? camera;
+  final String? cameraError;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Video Recorder App',
-      theme: AppTheme.lightTheme, // Light theme (optional)
-      darkTheme: AppTheme.darkTheme, // Dark theme
-      themeMode: ThemeMode.dark, // Set dark theme by default
-      home: SplashScreen(camera: camera), // Start with the SplashScreen
+      title: 'WODRepLog',
+      debugShowCheckedModeBanner: false,
+      theme: AppTheme.lightTheme,
+      darkTheme: AppTheme.darkTheme,
+      themeMode: ThemeMode.dark,
+      home: SplashScreen(
+        camera: camera,
+        cameraError: cameraError,
+      ),
     );
   }
 }

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -1,30 +1,48 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
-import 'home_screen.dart';
+
 import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+
+import 'home_screen.dart';
 
 class SplashScreen extends StatefulWidget {
-  final CameraDescription camera;
+  const SplashScreen({
+    super.key,
+    required this.camera,
+    this.cameraError,
+  });
 
-  const SplashScreen({super.key, required this.camera});
+  final CameraDescription? camera;
+  final String? cameraError;
 
   @override
   SplashScreenState createState() => SplashScreenState();
 }
 
 class SplashScreenState extends State<SplashScreen> {
+  Timer? _navigationTimer;
+
   @override
   void initState() {
     super.initState();
 
-    // Navigate to HomeScreen after 3 seconds
-    Timer(const Duration(seconds: 3), () {
+    _navigationTimer = Timer(const Duration(seconds: 3), () {
+      if (!mounted) return;
       Navigator.of(context).pushReplacement(
         MaterialPageRoute(
-          builder: (context) => HomeScreen(camera: widget.camera),
+          builder: (context) => HomeScreen(
+            camera: widget.camera,
+            cameraError: widget.cameraError,
+          ),
         ),
       );
     });
+  }
+
+  @override
+  void dispose() {
+    _navigationTimer?.cancel();
+    super.dispose();
   }
 
   @override
@@ -45,6 +63,20 @@ class SplashScreenState extends State<SplashScreen> {
               'WODRepLog',
               style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             ),
+            if (widget.cameraError != null) ...[
+              const SizedBox(height: 16),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                child: Text(
+                  widget.cameraError!,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Colors.redAccent,
+                    fontSize: 14,
+                  ),
+                ),
+              ),
+            ]
           ],
         ),
       ),

--- a/lib/video_recorder.dart
+++ b/lib/video_recorder.dart
@@ -1,37 +1,45 @@
 import 'dart:async';
 import 'dart:io';
+
+import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:camera/camera.dart';
-import 'package:path/path.dart' as path;
 import 'package:gallery_saver_plus/gallery_saver.dart';
+import 'package:path/path.dart' as path;
 
 class VideoRecorder extends StatefulWidget {
-  const VideoRecorder({super.key});
+  const VideoRecorder({
+    super.key,
+    required this.camera,
+  });
+
+  final CameraDescription camera;
 
   @override
   VideoRecorderState createState() => VideoRecorderState();
 }
 
 class VideoRecorderState extends State<VideoRecorder> {
-  late CameraController _controller;
+  CameraController? _controller;
+  late final Future<void> _initializationFuture;
+  String? _initializationError;
+
   bool _isRecording = false;
-  final bool _showTimer = false;
-  String competitionName = '';
-  String workoutName = '';
+  bool _isProcessingVideo = false;
   Timer? _timer;
   int _elapsedSeconds = 0;
+  bool _isTimerEnabled = false;
+  bool _autoStopAtTarget = false;
+  Duration? _targetDuration;
 
-  int _timerDuration = 30; // Example duration
-  int? _interval;
-  int? _rounds;
+  String competitionName = '';
+  String workoutName = '';
 
   @override
   void initState() {
     super.initState();
-    _initializeCamera();
+    _initializationFuture = _initializeCamera();
 
-    // Force landscape orientation and hide system UI when the camera view is active
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.landscapeRight,
       DeviceOrientation.landscapeLeft,
@@ -41,10 +49,9 @@ class VideoRecorderState extends State<VideoRecorder> {
 
   @override
   void dispose() {
-    _controller.dispose();
     _timer?.cancel();
+    _controller?.dispose();
 
-    // Reset orientation and show system UI when leaving the camera view
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
@@ -54,97 +61,188 @@ class VideoRecorderState extends State<VideoRecorder> {
   }
 
   Future<void> _initializeCamera() async {
+    final controller = CameraController(
+      widget.camera,
+      ResolutionPreset.high,
+      enableAudio: true,
+    );
+
     try {
-      final cameras = await availableCameras();
-      final camera = cameras.first;
-      _controller = CameraController(camera, ResolutionPreset.high);
-      await _controller.initialize();
+      await controller.initialize();
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+
+      setState(() {
+        _controller = controller;
+        _initializationError = null;
+      });
+    } on CameraException catch (error) {
+      await controller.dispose();
       if (!mounted) return;
-      setState(() {});
-    } catch (e) {
-      _showErrorSnackBar('Failed to initialize camera: $e');
+      setState(() {
+        _controller = null;
+        _initializationError = error.description ?? error.code;
+      });
+    } catch (error) {
+      await controller.dispose();
+      if (!mounted) return;
+      setState(() {
+        _controller = null;
+        _initializationError = error.toString();
+      });
+    }
+  }
+
+  Future<void> _startRecording() async {
+    final controller = _controller;
+    if (controller == null || !controller.value.isInitialized) {
+      _showErrorSnackBar('Camera is not ready yet.');
+      return;
+    }
+
+    if (_isProcessingVideo || controller.value.isRecordingVideo) {
+      return;
+    }
+
+    try {
+      try {
+        await controller.prepareForVideoRecording();
+      } catch (_) {
+        // Some platforms do not require prepareForVideoRecording.
+      }
+
+      await controller.startVideoRecording();
+      if (!mounted) return;
+
+      setState(() {
+        _isRecording = true;
+        _elapsedSeconds = 0;
+      });
+
+      if (_isTimerEnabled) {
+        _startTimer();
+      }
+    } catch (error) {
+      _showErrorSnackBar('Error starting video recording: $error');
+    }
+  }
+
+  Future<void> _stopRecording({bool autoStopped = false}) async {
+    final controller = _controller;
+    if (controller == null || !controller.value.isInitialized) {
+      return;
+    }
+
+    if (!controller.value.isRecordingVideo || _isProcessingVideo) {
+      _clearTimerState();
+      return;
+    }
+
+    setState(() {
+      _isProcessingVideo = true;
+    });
+
+    try {
+      final XFile videoFile = await controller.stopVideoRecording();
+      if (!mounted) {
+        _clearTimerState();
+        return;
+      }
+
+      setState(() {
+        _isRecording = false;
+        _clearTimerState();
+      });
+
+      final newFilePath = '${path.withoutExtension(videoFile.path)}.mp4';
+      final savedFile = await File(videoFile.path).rename(newFilePath);
+
+      final bool? success = await GallerySaver.saveVideo(savedFile.path);
+      if (!mounted) return;
+
+      if (success == true) {
+        _showSnackBar(
+          autoStopped
+              ? 'Recording stopped automatically and saved to gallery.'
+              : 'Video saved to gallery.',
+        );
+      } else {
+        _showErrorSnackBar('Failed to save video to gallery.');
+      }
+    } catch (error) {
+      if (mounted) {
+        _showErrorSnackBar('Error stopping video recording: $error');
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessingVideo = false;
+        });
+      } else {
+        _isProcessingVideo = false;
+      }
     }
   }
 
   void _startTimer() {
-    if (_interval == null || _rounds == null) return; // Ensure they are set
-    _elapsedSeconds = 0;
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (!mounted) return;
 
-    _timer = Timer.periodic(Duration(seconds: _interval!), (timer) {
+      if (!_isRecording) {
+        timer.cancel();
+        return;
+      }
+
       setState(() {
         _elapsedSeconds++;
-        if (_elapsedSeconds >= _rounds! * _timerDuration) {
-          _timer?.cancel();
-        }
       });
+
+      if (_autoStopAtTarget &&
+          _targetDuration != null &&
+          _elapsedSeconds >= _targetDuration!.inSeconds &&
+          !_isProcessingVideo) {
+        timer.cancel();
+        _stopRecording(autoStopped: true);
+      }
     });
   }
 
-  void _stopTimer() {
+  void _clearTimerState() {
     _timer?.cancel();
-  }
-
-  Future<void> _startRecording() async {
-    if (!_controller.value.isInitialized) return;
-
-    try {
-      await _controller.startVideoRecording();
-      setState(() {
-        _isRecording = true;
-      });
-      if (_showTimer) {
-        _startTimer(); // Start the timer when recording starts
-      }
-    } catch (e) {
-      _showErrorSnackBar('Error starting video recording: $e');
-    }
-  }
-
-  Future<void> _stopRecording() async {
-    if (!_controller.value.isInitialized || !_isRecording) return;
-
-    try {
-      final XFile videoFile = await _controller.stopVideoRecording();
-      setState(() {
-        _isRecording = false;
-      });
-      _stopTimer(); // Stop the timer when recording stops
-
-      final newFilePath = '${path.withoutExtension(videoFile.path)}.mp4';
-      await File(videoFile.path).rename(newFilePath);
-
-      final bool? success = await GallerySaver.saveVideo(newFilePath);
-      if (success == true) {
-        _showSnackBar('Video saved to gallery');
-      } else {
-        _showErrorSnackBar('Failed to save video to gallery');
-      }
-    } catch (e) {
-      _showErrorSnackBar('Error stopping video recording: $e');
-    }
+    _timer = null;
+    _elapsedSeconds = 0;
   }
 
   void _showSnackBar(String message) {
+    if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(message)),
     );
   }
 
   void _showErrorSnackBar(String message) {
+    if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message), backgroundColor: Colors.red),
+      SnackBar(
+        content: Text(message),
+        backgroundColor: Colors.redAccent,
+      ),
     );
   }
 
-  void _showInputDialog() {
-    final competitionController = TextEditingController(text: competitionName);
-    final workoutController = TextEditingController(text: workoutName);
-
-    showDialog(
+  Future<void> _showInputDialog() async {
+    final details = await showDialog<_CompetitionDetails>(
       context: context,
       builder: (BuildContext context) {
+        final competitionController =
+            TextEditingController(text: competitionName);
+        final workoutController = TextEditingController(text: workoutName);
+
         return AlertDialog(
-          title: const Text('Enter Details'),
+          title: const Text('Overlay Details'),
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -153,188 +251,409 @@ class VideoRecorderState extends State<VideoRecorder> {
                 decoration: const InputDecoration(
                   labelText: 'Competition Name',
                 ),
+                textCapitalization: TextCapitalization.words,
               ),
               TextField(
                 controller: workoutController,
                 decoration: const InputDecoration(
                   labelText: 'Workout Name',
                 ),
+                textCapitalization: TextCapitalization.words,
               ),
             ],
           ),
           actions: [
             TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
+              onPressed: () => Navigator.of(context).pop(),
               child: const Text('Cancel'),
             ),
             TextButton(
               onPressed: () {
-                setState(() {
-                  competitionName = competitionController.text;
-                  workoutName = workoutController.text;
-                });
-                Navigator.of(context).pop();
+                Navigator.of(context).pop(
+                  _CompetitionDetails(
+                    competition: competitionController.text.trim(),
+                    workout: workoutController.text.trim(),
+                  ),
+                );
               },
-              child: const Text('OK'),
+              child: const Text('Save'),
             ),
           ],
         );
       },
     );
+
+    if (details != null && mounted) {
+      setState(() {
+        competitionName = details.competition;
+        workoutName = details.workout;
+      });
+    }
   }
 
-  void _showTimerConfigDialog() {
-    showDialog(
+  Future<void> _showTimerConfigDialog() async {
+    final formKey = GlobalKey<FormState>();
+    bool timerEnabled = _isTimerEnabled;
+    bool autoStop = _autoStopAtTarget;
+    String? validationMessage;
+
+    final minutesController = TextEditingController(
+      text: _targetDuration != null
+          ? _targetDuration!.inMinutes.toString()
+          : '0',
+    );
+    final secondsController = TextEditingController(
+      text: _targetDuration != null
+          ? (_targetDuration!.inSeconds % 60).toString()
+          : '0',
+    );
+
+    StateSetter? dialogSetState;
+
+    final settings = await showDialog<_TimerSettings>(
       context: context,
-      builder: (BuildContext context) {
+      builder: (context) {
         return AlertDialog(
-          title: const Text('Configure Timer'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextField(
-                decoration:
-                    const InputDecoration(labelText: 'Duration (seconds)'),
-                keyboardType: TextInputType.number,
-                onChanged: (value) {
-                  setState(() {
-                    _timerDuration = int.parse(value);
-                  });
-                },
-              ),
-              TextField(
-                decoration:
-                    const InputDecoration(labelText: 'Interval (seconds)'),
-                keyboardType: TextInputType.number,
-                onChanged: (value) {
-                  setState(() {
-                    _interval = int.parse(value);
-                  });
-                },
-              ),
-              TextField(
-                decoration: const InputDecoration(labelText: 'Rounds'),
-                keyboardType: TextInputType.number,
-                onChanged: (value) {
-                  setState(() {
-                    _rounds = int.parse(value);
-                  });
-                },
-              ),
-            ],
+          title: const Text('Recording Timer'),
+          content: StatefulBuilder(
+            builder: (context, setDialogState) {
+              dialogSetState = setDialogState;
+              return Form(
+                key: formKey,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SwitchListTile(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Show timer while recording'),
+                      value: timerEnabled,
+                      onChanged: (value) {
+                        setDialogState(() {
+                          timerEnabled = value;
+                          validationMessage = null;
+                        });
+                      },
+                    ),
+                    if (timerEnabled) ...[
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: minutesController,
+                              keyboardType: TextInputType.number,
+                              decoration:
+                                  const InputDecoration(labelText: 'Minutes'),
+                              validator: (value) {
+                                final parsed = int.tryParse(value ?? '');
+                                if (parsed == null || parsed < 0) {
+                                  return 'Enter a valid number';
+                                }
+                                return null;
+                              },
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: TextFormField(
+                              controller: secondsController,
+                              keyboardType: TextInputType.number,
+                              decoration:
+                                  const InputDecoration(labelText: 'Seconds'),
+                              validator: (value) {
+                                final parsed = int.tryParse(value ?? '');
+                                if (parsed == null || parsed < 0 || parsed > 59) {
+                                  return '0 - 59';
+                                }
+                                return null;
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+                      SwitchListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: const Text('Stop automatically at target time'),
+                        value: autoStop,
+                        onChanged: (value) {
+                          setDialogState(() {
+                            autoStop = value;
+                            validationMessage = null;
+                          });
+                        },
+                      ),
+                      if (validationMessage != null)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8.0),
+                          child: Text(
+                            validationMessage!,
+                            style: const TextStyle(
+                              color: Colors.redAccent,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ],
+                ),
+              );
+            },
           ),
           actions: [
             TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
               onPressed: () {
-                Navigator.of(context).pop();
+                if (timerEnabled && !formKey.currentState!.validate()) {
+                  return;
+                }
+
+                final minutes = int.tryParse(minutesController.text) ?? 0;
+                final seconds = int.tryParse(secondsController.text) ?? 0;
+
+                if (timerEnabled && autoStop && minutes == 0 && seconds == 0) {
+                  dialogSetState?.call(() {
+                    validationMessage =
+                        'Set a duration greater than zero for auto stop.';
+                  });
+                  return;
+                }
+
+                final durationSeconds = (minutes * 60) + seconds;
+                Navigator.of(context).pop(
+                  _TimerSettings(
+                    enabled: timerEnabled,
+                    autoStop: timerEnabled ? autoStop : false,
+                    duration:
+                        timerEnabled && durationSeconds > 0
+                            ? Duration(seconds: durationSeconds)
+                            : null,
+                  ),
+                );
               },
-              child: const Text('OK'),
+              child: const Text('Save'),
             ),
           ],
         );
       },
     );
+
+    if (settings != null && mounted) {
+      setState(() {
+        _isTimerEnabled = settings.enabled;
+        _autoStopAtTarget = settings.autoStop;
+        _targetDuration = settings.duration;
+      });
+    }
   }
 
-  String _formatTime(int seconds) {
+  String _formatSeconds(int seconds) {
     final minutes = seconds ~/ 60;
     final remainingSeconds = seconds % 60;
-    return '$minutes:${remainingSeconds.toString().padLeft(2, '0')}';
+    return '${minutes.toString().padLeft(2, '0')}:${remainingSeconds.toString().padLeft(2, '0')}';
+  }
+
+  Widget _buildCameraPreview() {
+    if (_initializationError != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Text(
+            _initializationError!,
+            textAlign: TextAlign.center,
+            style: const TextStyle(color: Colors.redAccent),
+          ),
+        ),
+      );
+    }
+
+    final controller = _controller;
+    if (controller == null || !controller.value.isInitialized) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return Container(
+      color: Colors.black,
+      alignment: Alignment.center,
+      child: AspectRatio(
+        aspectRatio: controller.value.aspectRatio,
+        child: CameraPreview(controller),
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    if (!_controller.value.isInitialized) {
-      return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
-      );
+    return Scaffold(
+      body: FutureBuilder<void>(
+        future: _initializationFuture,
+        builder: (context, snapshot) {
+          return Stack(
+            children: [
+              Positioned.fill(child: _buildCameraPreview()),
+              if (competitionName.isNotEmpty)
+                Positioned(
+                  top: 24,
+                  left: 24,
+                  child: Text(
+                    competitionName,
+                    style: const TextStyle(
+                      fontSize: 24,
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              if (workoutName.isNotEmpty)
+                Positioned(
+                  bottom: 24,
+                  left: 24,
+                  child: Text(
+                    workoutName,
+                    style: const TextStyle(
+                      fontSize: 20,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              if (_isRecording && _isTimerEnabled)
+                Positioned(
+                  top: 24,
+                  right: 24,
+                  child: _TimerChip(
+                    elapsed: _elapsedSeconds,
+                    target: _targetDuration?.inSeconds,
+                    autoStop: _autoStopAtTarget,
+                    formatter: _formatSeconds,
+                  ),
+                ),
+            ],
+          );
+        },
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              FloatingActionButton.small(
+                heroTag: 'timer-config',
+                onPressed: _isProcessingVideo ? null : _showTimerConfigDialog,
+                child: const Icon(Icons.timer_outlined),
+              ),
+              FloatingActionButton(
+                heroTag: 'record',
+                onPressed: _isProcessingVideo
+                    ? null
+                    : _isRecording
+                        ? () => _stopRecording()
+                        : _startRecording,
+                child: _isProcessingVideo
+                    ? const SizedBox(
+                        height: 24,
+                        width: 24,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2.5,
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            Colors.white,
+                          ),
+                        ),
+                      )
+                    : Icon(
+                        _isRecording
+                            ? Icons.stop
+                            : Icons.fiber_manual_record,
+                      ),
+              ),
+              FloatingActionButton.small(
+                heroTag: 'details',
+                onPressed: _isProcessingVideo ? null : _showInputDialog,
+                child: const Icon(Icons.edit),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TimerChip extends StatelessWidget {
+  const _TimerChip({
+    required this.elapsed,
+    required this.formatter,
+    this.target,
+    this.autoStop = false,
+  });
+
+  final int elapsed;
+  final int? target;
+  final bool autoStop;
+  final String Function(int seconds) formatter;
+
+  @override
+  Widget build(BuildContext context) {
+    final buffer = StringBuffer(formatter(elapsed));
+    if (target != null) {
+      buffer.write(' / ');
+      buffer.write(formatter(target!));
     }
 
-    return Scaffold(
-      body: Stack(
-        children: [
-          Center(
-            // Center the FittedBox horizontally with a 180-degree rotation
-            child: Transform.rotate(
-              angle: 3.14159, // 180 degrees in radians
-              child: FittedBox(
-                fit: BoxFit.cover,
-                child: SizedBox(
-                  width: _controller.value.previewSize!.width,
-                  height: _controller.value.previewSize!.height,
-                  child: CameraPreview(_controller),
-                ),
-              ),
-            ),
-          ),
-          Positioned(
-            top: 20,
-            left: 20,
-            child: Text(
-              competitionName,
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.black.withOpacity(0.6),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              buffer.toString(),
               style: const TextStyle(
-                fontSize: 24,
+                fontSize: 20,
                 color: Colors.white,
                 fontWeight: FontWeight.bold,
               ),
             ),
-          ),
-          Positioned(
-            bottom: 20,
-            left: 20,
-            child: Text(
-              workoutName,
-              style: const TextStyle(
-                fontSize: 20,
-                color: Colors.white,
-              ),
-            ),
-          ),
-          if (_isRecording && _showTimer)
-            Positioned(
-              top: 20,
-              right: 20,
-              child: Text(
-                _formatTime(_elapsedSeconds),
-                style: const TextStyle(
-                  fontSize: 24,
-                  color: Colors.red,
-                  fontWeight: FontWeight.bold,
+            if (autoStop && target != null)
+              const Text(
+                'Auto stop enabled',
+                style: TextStyle(
+                  color: Colors.white70,
+                  fontSize: 12,
                 ),
               ),
-            ),
-        ],
-      ),
-      floatingActionButton: Stack(
-        children: [
-          Positioned(
-            bottom: 16,
-            left: MediaQuery.of(context).size.width / 2 - 28,
-            child: FloatingActionButton(
-              onPressed: _isRecording ? _stopRecording : _startRecording,
-              child: Icon(_isRecording ? Icons.stop : Icons.videocam),
-            ),
-          ),
-          Positioned(
-            bottom: 90,
-            right: 16,
-            child: FloatingActionButton(
-              onPressed: _showTimerConfigDialog,
-              child: const Icon(Icons.timer),
-            ),
-          ),
-          Positioned(
-            bottom: 16,
-            right: 16,
-            child: FloatingActionButton(
-              onPressed: _showInputDialog,
-              child: const Icon(Icons.edit),
-            ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
+}
+
+class _CompetitionDetails {
+  const _CompetitionDetails({
+    required this.competition,
+    required this.workout,
+  });
+
+  final String competition;
+  final String workout;
+}
+
+class _TimerSettings {
+  const _TimerSettings({
+    required this.enabled,
+    required this.autoStop,
+    this.duration,
+  });
+
+  final bool enabled;
+  final bool autoStop;
+  final Duration? duration;
 }


### PR DESCRIPTION
## Summary
- add robust camera initialization with graceful error messaging that flows from the splash screen to the home screen
- disable the video recorder shortcut when no camera is available and surface any camera errors on the home view
- refactor the video recorder to reuse the selected camera, add validation-backed overlay configuration, and provide an optional auto-stop recording timer

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3737fac588327b2496313c4528fd1