### PR TITLE
Automate Play Store publishing for master and release branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
-name: Publish
+name: Publish Android Tracks
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
+      - release
 
 jobs:
   build:
@@ -11,8 +13,6 @@ jobs:
       # Setup env variables that will be used throughout the workflow
       JAVA_VERSION: 19.0
       FLUTTER_VERSION: 3.35.5
-      VERSION_NAME: ${{ github.event.release.tag_name }}
-      VERSION_CODE: ${{github.run_number}}
 
     steps:
       # Checkout repository codebase
@@ -54,9 +54,34 @@ jobs:
       - name: 🕵️ flutter doctor --verbose
         run: flutter doctor --verbose
 
+      - name: Extract version from pubspec.yaml
+        id: app_version
+        run: |
+          set -eo pipefail
+          VERSION_VALUE=$(grep '^version:' pubspec.yaml | head -n 1 | sed 's/version:[[:space:]]*//')
+          VERSION_NAME=${VERSION_VALUE%%+*}
+          if [[ "$VERSION_VALUE" == *"+"* ]]; then
+            VERSION_CODE=${VERSION_VALUE##*+}
+          else
+            VERSION_CODE=${GITHUB_RUN_NUMBER}
+          fi
+          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Determine Play Store track
+        id: track
+        run: |
+          if [ "$GITHUB_REF" = "refs/heads/release" ]; then
+            echo "track=production" >> "$GITHUB_OUTPUT"
+            echo "status=completed" >> "$GITHUB_OUTPUT"
+          else
+            echo "track=internal" >> "$GITHUB_OUTPUT"
+            echo "status=completed" >> "$GITHUB_OUTPUT"
+          fi
+
       # Bundle
       - name: Build release app bundle
-        run: flutter build appbundle --release --build-number=${{ env.VERSION_CODE }} --build-name=${{ env.VERSION_NAME }}
+        run: flutter build appbundle --release --build-number=${{ steps.app_version.outputs.version_code }} --build-name=${{ steps.app_version.outputs.version_name }}
 
       - name: Sign App Bundle
         uses: r0adkll/sign-android-release@v1
@@ -68,12 +93,13 @@ jobs:
           keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
 
-      - name: Upload to Play Store (Internal Testing)
+      - name: Upload to Play Store
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: ch.joshuahemmings.wodreplog
           releaseFiles: ${{steps.sign_app.outputs.signedReleaseFile}}
-          releaseName: ${{ github.event.release.tag_name }}
+          releaseName: ${{ steps.app_version.outputs.version_name }}
           mappingFile: build/app/outputs/mapping/release/mapping.txt
-          track: internal
+          track: ${{ steps.track.outputs.track }}
+          status: ${{ steps.track.outputs.status }}

--- a/docs/internal-testing-release.md
+++ b/docs/internal-testing-release.md
@@ -1,0 +1,13 @@
+# Internal Testing Release Branch
+
+This branch was created to prepare the current development build for internal testing and now automatically publishes internal builds when changes land on `master`.
+
+## Purpose
+- Merge the latest changes from the `dev` branch.
+- Prepare the build for distribution through internal App Store / TestFlight channels.
+- Ensure that any public release increments the application version before being merged into `master`.
+
+## Next Steps
+1. Review and merge any outstanding changes from `dev` into this branch.
+2. Push changes that are ready for internal testing to `master`; the GitHub Actions publish pipeline will automatically ship the build to the Google Play internal testing track.
+3. To prepare a public release, bump the app version, merge the changes into the `release` branch, and allow the pipeline to publish to production on the Google Play Store.


### PR DESCRIPTION
## Summary
- update the Play Store workflow to trigger on pushes to `master` and `release`, automatically selecting the internal or production track
- derive build names and codes from `pubspec.yaml` before bundling and publishing the Android app
- refresh the internal testing branch documentation to reflect the new automated publishing flow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e37854779c8327b47b295ec169618f