### PR TITLE
Automate patch version bump in test publish workflow

### DIFF
--- a/.github/workflows/publish_TEST.yml
+++ b/.github/workflows/publish_TEST.yml
@@ -7,18 +7,45 @@ on:
 
 jobs:
   build:
+    if: ${{ github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     env:
       # Setup env variables that will be used throughout the workflow
       JAVA_VERSION: 19.0
       FLUTTER_VERSION: 3.35.5
-      VERSION_NAME: ${{ github.event.release.tag_name }}
       VERSION_CODE: ${{github.run_number}}
 
     steps:
       # Checkout repository codebase
       - name: Checkout the code
         uses: actions/checkout@v5
+
+      - name: Bump patch version
+        id: bump_version
+        run: |
+          current_version=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+          version_core=${current_version%%+*}
+          if [[ "$current_version" == *"+"* ]]; then
+            build_suffix="+${current_version#*+}"
+          else
+            build_suffix=""
+          fi
+          IFS='.' read -r major minor patch <<< "$version_core"
+          patch=$((patch + 1))
+          new_version="${major}.${minor}.${patch}${build_suffix}"
+          echo "Bumping version: ${current_version} -> ${new_version}"
+          sed -i "s/^version: .*/version: ${new_version}/" pubspec.yaml
+          echo "new_version=${new_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Export version to environment
+        run: echo "VERSION_NAME=${{ steps.bump_version.outputs.new_version }}" >> "$GITHUB_ENV"
+
+      - name: Commit version bump
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: chore: bump test build version to ${{ steps.bump_version.outputs.new_version }} [skip ci]
+          branch: ${{ github.ref_name }}
+          file_pattern: pubspec.yaml
 
       # Setup Java in the VM
       - uses: actions/setup-java@v5
@@ -48,7 +75,7 @@ jobs:
 
       # Bundle
       - name: Build release app bundle
-        run: flutter build appbundle --release --build-number=${{ env.VERSION_CODE }} --build-name=${{ env.VERSION_NAME }}
+        run: flutter build appbundle --release --build-number=${{ env.VERSION_CODE }} --build-name=${{ steps.bump_version.outputs.new_version }}
 
       - name: Sign App Bundle
         uses: r0adkll/sign-android-release@v1
@@ -66,6 +93,6 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: ch.joshuahemmings.wodreplog
           releaseFiles: ${{steps.sign_app.outputs.signedReleaseFile}}
-          releaseName: ${{ github.event.release.tag_name }}
+          releaseName: ${{ steps.bump_version.outputs.new_version }}
           mappingFile: build/app/outputs/mapping/release/mapping.txt
           track: internal


### PR DESCRIPTION
## Summary
- add a job guard to skip reruns triggered by the GitHub Actions bot
- bump the Flutter package patch version within the publish_TEST workflow and export it for subsequent steps
- auto-commit the version change and use the new version when building and uploading the bundle

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3cced3ee483279733b9be3bb28406