### PR TITLE
Fix YAML string quoting in test publish workflow

### DIFF
--- a/.github/workflows/publish_TEST.yml
+++ b/.github/workflows/publish_TEST.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Commit version bump
         uses: stefanzweifel/git-auto-commit-action@v6
         with:
-          commit_message: chore: bump test build version to ${{ steps.bump_version.outputs.new_version }} [skip ci]
+          commit_message: "chore: bump test build version to ${{ steps.bump_version.outputs.new_version }} [skip ci]"
           branch: ${{ github.ref_name }}
           file_pattern: pubspec.yaml
 


### PR DESCRIPTION
## Summary
- quote the auto-commit message string in the publish_TEST workflow to satisfy YAML syntax rules

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3d499e49c83279814c03f5b08e8e7