### PR TITLE
Ensure Play Store build number increments in test publish workflow

### DIFF
--- a/.github/workflows/publish_TEST.yml
+++ b/.github/workflows/publish_TEST.yml
@@ -13,7 +13,6 @@ jobs:
       # Setup env variables that will be used throughout the workflow
       JAVA_VERSION: 19.0
       FLUTTER_VERSION: 3.35.5
-      VERSION_CODE: ${{github.run_number}}
 
     steps:
       # Checkout repository codebase
@@ -26,24 +25,32 @@ jobs:
           current_version=$(grep '^version:' pubspec.yaml | awk '{print $2}')
           version_core=${current_version%%+*}
           if [[ "$current_version" == *"+"* ]]; then
-            build_suffix="+${current_version#*+}"
+            build_suffix=${current_version#*+}
           else
             build_suffix=""
           fi
           IFS='.' read -r major minor patch <<< "$version_core"
           patch=$((patch + 1))
-          new_version="${major}.${minor}.${patch}${build_suffix}"
+          if [[ "$build_suffix" =~ ^[0-9]+$ ]]; then
+            new_build_number=$((build_suffix + 1))
+          else
+            new_build_number=1
+          fi
+          new_version="${major}.${minor}.${patch}+${new_build_number}"
           echo "Bumping version: ${current_version} -> ${new_version}"
           sed -i "s/^version: .*/version: ${new_version}/" pubspec.yaml
           echo "new_version=${new_version}" >> "$GITHUB_OUTPUT"
+          echo "new_build_number=${new_build_number}" >> "$GITHUB_OUTPUT"
 
       - name: Export version to environment
-        run: echo "VERSION_NAME=${{ steps.bump_version.outputs.new_version }}" >> "$GITHUB_ENV"
+        run: |
+          echo "VERSION_NAME=${{ steps.bump_version.outputs.new_version }}" >> "$GITHUB_ENV"
+          echo "VERSION_CODE=${{ steps.bump_version.outputs.new_build_number }}" >> "$GITHUB_ENV"
 
       - name: Commit version bump
         uses: stefanzweifel/git-auto-commit-action@v6
         with:
-          commit_message: chore: bump test build version to ${{ steps.bump_version.outputs.new_version }} [skip ci]
+          commit_message: "chore: bump test build version to ${{ steps.bump_version.outputs.new_version }} [skip ci]"
           branch: ${{ github.ref_name }}
           file_pattern: pubspec.yaml
 
@@ -75,7 +82,11 @@ jobs:
 
       # Bundle
       - name: Build release app bundle
-        run: flutter build appbundle --release --build-number=${{ env.VERSION_CODE }} --build-name=${{ steps.bump_version.outputs.new_version }}
+        run: |
+          flutter build appbundle \
+            --release \
+            --build-number=${{ steps.bump_version.outputs.new_build_number }} \
+            --build-name=${{ steps.bump_version.outputs.new_version }}
 
       - name: Sign App Bundle
         uses: r0adkll/sign-android-release@v1
@@ -92,7 +103,7 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: ch.joshuahemmings.wodreplog
-          releaseFiles: ${{steps.sign_app.outputs.signedReleaseFile}}
+          releaseFiles: ${{ steps.sign_app.outputs.signedReleaseFile }}
           releaseName: ${{ steps.bump_version.outputs.new_version }}
           mappingFile: build/app/outputs/mapping/release/mapping.txt
           track: internal


### PR DESCRIPTION
## Summary
- update the test publish workflow to compute a monotonically increasing build number alongside the version name
- export the computed build number to the environment and reuse it for flutter build and the Play Store upload step

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e3d499e49c83279814c03f5b08e8e7