### PR TITLE
Ensure Android build number derived from version components

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.22+3
+version: 0.0.22+4
 environment:
   sdk: ">=3.3.0 <4.0.0"
   flutter: 3.35.5

--- a/scripts/manage_version.sh
+++ b/scripts/manage_version.sh
@@ -67,14 +67,52 @@ emit_outputs() {
   local new_version=$1
   local build_number=$2
   local base_version=$3
+  local build_suffix=$4
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     {
       echo "new_version=$new_version"
       echo "build_number=$build_number"
       echo "base_version=$base_version"
+      echo "build_suffix=$build_suffix"
     } >> "$GITHUB_OUTPUT"
   fi
   echo "$new_version"
+}
+
+compute_version_code() {
+  local core_version=$1
+  local build_suffix=$2
+  python - "$core_version" "$build_suffix" <<'PY'
+import sys
+
+core = sys.argv[1]
+suffix = sys.argv[2]
+
+parts = core.split('.')
+if len(parts) != 3:
+    raise SystemExit("Version core must have three segments (major.minor.patch)")
+
+try:
+    major, minor, patch = [int(part) for part in parts]
+    build = int(suffix)
+except ValueError as exc:
+    raise SystemExit(f"Version components must be integers: {exc}") from exc
+
+def ensure_range(name, value, upper):
+    if value < 0 or value > upper:
+        raise SystemExit(f"{name} component must be between 0 and {upper}, got {value}")
+
+ensure_range("major", major, 99)
+ensure_range("minor", minor, 99)
+ensure_range("patch", patch, 99)
+ensure_range("build", build, 9999)
+
+version_code = int(f"{major:02d}{minor:02d}{patch:02d}{build:04d}")
+if version_code > 2100000000:
+    raise SystemExit("Computed version code exceeds Android limit of 2100000000")
+
+print(version_code)
+PY
 }
 
 increment_build() {
@@ -88,8 +126,10 @@ increment_build() {
   build=$(extract_build_number "$current")
   local new_build=$((build + 1))
   local new_version="${core}+${new_build}"
+  local version_code
+  version_code=$(compute_version_code "$core" "$new_build")
   write_version "$new_version"
-  emit_outputs "$new_version" "$new_build" "$core"
+  emit_outputs "$new_version" "$version_code" "$core" "$new_build"
 }
 
 set_release_version() {
@@ -111,8 +151,10 @@ set_release_version() {
     new_build=1
   fi
   local new_version="${release_version}+${new_build}"
+  local version_code
+  version_code=$(compute_version_code "$release_version" "$new_build")
   write_version "$new_version"
-  emit_outputs "$new_version" "$new_build" "$release_version"
+  emit_outputs "$new_version" "$version_code" "$release_version" "$new_build"
 }
 
 main() {


### PR DESCRIPTION
## Summary
- compute a deterministic Android version code from the semantic version in manage_version.sh
- expose the calculated build suffix alongside the unique build number for downstream steps
- prevent publishing workflows from reusing a build-number that would block Play Store uploads

## Testing
- PUBSPEC_FILE=$(mktemp) ./scripts/manage_version.sh increment-build

------
https://chatgpt.com/codex/tasks/task_e_68e60e209a6483278decc70dbec0c29f