### PR TITLE
Pin Flutter SDK version for GitHub Actions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ version: 0.1.5
 
 environment:
   sdk: ">=3.12.1 <4.0.0"
-  flutter: ">=3.44.1"
+  flutter: 3.44.1
 # Dependencies specify other packages that your package needs in order to work.
 
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
### Motivation
- The GitHub Action `subosito/flutter-action@v2` failed to resolve `flutter-version-file: pubspec.yaml` because the `environment.flutter` entry used a range (`">=3.44.1"`) instead of an exact SDK version.

### Description
- Change the `environment.flutter` entry in `pubspec.yaml` from `">=3.44.1"` to `3.44.1` so the action can deterministically pick the SDK.
- No other files were modified.

### Testing
- Verified the `pubspec.yaml` line is exactly `flutter: 3.44.1` using a Python assertion (succeeded).
- Ran `git diff --check` to ensure no whitespace or diff errors (succeeded).
- Attempted `flutter --version` in the current environment but Flutter is not installed here, so action runtime verification could not be performed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43c0a12d0c8327a1cd6fa619bf374d)